### PR TITLE
Add JSONL-based live chat view for agent sessions

### DIFF
--- a/src/corral/jsonl_reader.py
+++ b/src/corral/jsonl_reader.py
@@ -1,0 +1,263 @@
+"""Efficient incremental JSONL reader for live Claude session transcripts."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from corral.utils import HISTORY_PATH
+
+log = logging.getLogger(__name__)
+
+PULSE_RE = re.compile(r"\|\|PULSE:\w+[^|]*\|\|")
+
+
+@dataclass
+class _SessionCache:
+    path: Path | None = None
+    offset: int = 0
+    messages: list[dict[str, Any]] = field(default_factory=list)
+    # Map tool_use_id → tool_name for labeling results
+    tool_use_names: dict[str, str] = field(default_factory=dict)
+
+
+def _encode_dir(directory: str) -> str:
+    """Encode a working directory path to the Claude projects folder name."""
+    return directory.replace("/", "-")
+
+
+def _summarize_tool_input(name: str, inp: dict[str, Any]) -> str:
+    """Compact summary of tool input for display."""
+    if name in ("Read", "Edit", "Write", "NotebookEdit"):
+        return inp.get("file_path", inp.get("notebook_path", ""))
+    if name == "Bash":
+        cmd = inp.get("command", "")
+        return cmd[:120] + ("..." if len(cmd) > 120 else "")
+    if name in ("Grep", "Glob"):
+        pattern = inp.get("pattern", "")
+        path = inp.get("path", "")
+        return f"{pattern}" + (f" in {path}" if path else "")
+    if name == "Agent":
+        return inp.get("description", inp.get("prompt", ""))[:120]
+    if name in ("TaskCreate", "TaskUpdate"):
+        return inp.get("subject", inp.get("taskId", ""))
+    if name == "WebSearch":
+        return inp.get("query", "")
+    if name == "WebFetch":
+        return inp.get("url", "")
+    # Fallback: first string value
+    for v in inp.values():
+        if isinstance(v, str) and v:
+            return v[:100]
+    return ""
+
+
+def _parse_entry(
+    entry: dict[str, Any], cache: _SessionCache | None = None
+) -> list[dict[str, Any]] | dict[str, Any] | None:
+    """Convert a raw JSONL entry into normalized frontend message(s).
+
+    When *cache* is provided, tool_use_id → tool_name mapping is used to
+    label tool_result messages.  May return a list of messages when a user
+    entry contains multiple tool_results.
+    """
+    etype = entry.get("type")
+    timestamp = entry.get("timestamp", "")
+
+    if etype == "user":
+        msg = entry.get("message", {})
+        content = msg.get("content", "")
+        # User messages can be a string or list with tool_result blocks
+        if isinstance(content, list):
+            text_parts = [b.get("text", "") for b in content if b.get("type") == "text"]
+            results: list[dict[str, Any]] = []
+            for b in content:
+                if b.get("type") == "tool_result":
+                    tool_use_id = b.get("tool_use_id", "")
+                    result_content = b.get("content", "")
+                    is_error = b.get("is_error", False)
+                    if isinstance(result_content, list):
+                        result_content = "\n".join(
+                            p.get("text", "") for p in result_content if p.get("type") == "text"
+                        )
+                    if not result_content:
+                        continue
+                    # Truncate very long results
+                    if len(result_content) > 10000:
+                        result_content = result_content[:10000] + "\n... (truncated)"
+                    # Look up tool name from cache
+                    tool_name = ""
+                    if cache and tool_use_id:
+                        tool_name = cache.tool_use_names.get(tool_use_id, "")
+                    results.append({
+                        "type": "tool_result",
+                        "timestamp": timestamp,
+                        "content": result_content,
+                        "tool_name": tool_name,
+                        "tool_use_id": tool_use_id,
+                        "is_error": is_error,
+                    })
+            if results:
+                return results
+            # Otherwise treat as normal user text
+            if not text_parts:
+                return None
+            content = "\n".join(text_parts)
+        if not content.strip():
+            return None
+        return {"type": "user", "timestamp": timestamp, "content": content}
+
+    if etype == "assistant":
+        msg = entry.get("message", {})
+        content = msg.get("content", [])
+        if isinstance(content, str):
+            text = content
+            tool_uses = []
+        elif isinstance(content, list):
+            text_parts = []
+            tool_uses = []
+            for block in content:
+                bt = block.get("type")
+                if bt == "text":
+                    text_parts.append(block.get("text", ""))
+                elif bt == "tool_use":
+                    tool_name = block.get("name", "")
+                    tool_use_id = block.get("id", "")
+                    tool_input = block.get("input", {})
+                    tool_entry: dict[str, Any] = {
+                        "name": tool_name,
+                        "tool_use_id": tool_use_id,
+                        "input_summary": _summarize_tool_input(tool_name, tool_input),
+                    }
+                    # Include full command and description for Bash
+                    if tool_name == "Bash":
+                        tool_entry["command"] = tool_input.get("command", "")
+                        desc = tool_input.get("description", "")
+                        if desc:
+                            tool_entry["description"] = desc
+                    # Include structured question data for AskUserQuestion
+                    elif tool_name == "AskUserQuestion":
+                        questions = tool_input.get("questions", [])
+                        if questions:
+                            tool_entry["questions"] = questions
+                    # Include diff data for Edit tools
+                    elif tool_name == "Edit":
+                        old = tool_input.get("old_string", "")
+                        new = tool_input.get("new_string", "")
+                        if old or new:
+                            tool_entry["old_string"] = old
+                            tool_entry["new_string"] = new
+                    # Include content for Write tools
+                    elif tool_name == "Write":
+                        content_str = tool_input.get("content", "")
+                        if content_str:
+                            if len(content_str) > 10000:
+                                content_str = content_str[:10000] + "\n... (truncated)"
+                            tool_entry["write_content"] = content_str
+                    tool_uses.append(tool_entry)
+            text = "\n".join(text_parts)
+        else:
+            return None
+
+        # Strip PULSE markers from text
+        text = PULSE_RE.sub("", text).strip()
+
+        if not text and not tool_uses:
+            return None
+
+        return {
+            "type": "assistant",
+            "timestamp": timestamp,
+            "text": text,
+            "tool_uses": tool_uses,
+        }
+
+    # Skip file-history-snapshot, progress, etc.
+    return None
+
+
+class JsonlSessionReader:
+    """Incrementally reads JSONL session files for live chat display."""
+
+    def __init__(self) -> None:
+        self._cache: dict[str, _SessionCache] = {}
+
+    def _resolve_path(self, session_id: str, working_directory: str = "") -> Path | None:
+        """Find the JSONL file for a session. Uses working_directory hint for fast lookup."""
+        # Try direct path using encoded working directory
+        if working_directory:
+            encoded = _encode_dir(working_directory)
+            candidate = HISTORY_PATH / encoded / f"{session_id}.jsonl"
+            if candidate.exists():
+                return candidate
+
+        # Fallback: search all project directories
+        for jsonl_path in HISTORY_PATH.rglob(f"{session_id}.jsonl"):
+            return jsonl_path
+
+        return None
+
+    def read_new_messages(
+        self, session_id: str, working_directory: str = ""
+    ) -> tuple[list[dict[str, Any]], int]:
+        """Read new messages since last call.
+
+        Returns (new_messages, total_count).
+        """
+        cache = self._cache.get(session_id)
+        if cache is None:
+            cache = _SessionCache()
+            self._cache[session_id] = cache
+
+        # Resolve path on first call or if not found yet
+        if cache.path is None:
+            cache.path = self._resolve_path(session_id, working_directory)
+            if cache.path is None:
+                return [], 0
+
+        # Read new data from file
+        try:
+            with open(cache.path, "r", errors="replace") as f:
+                f.seek(cache.offset)
+                new_data = f.read()
+                cache.offset = f.tell()
+        except OSError:
+            return [], len(cache.messages)
+
+        if not new_data:
+            return [], len(cache.messages)
+
+        # Parse new lines
+        new_messages = []
+        for line in new_data.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            parsed = _parse_entry(entry, cache)
+            if parsed is None:
+                continue
+            # _parse_entry may return a list (multiple tool_results) or a single dict
+            items = parsed if isinstance(parsed, list) else [parsed]
+            for item in items:
+                # Register tool_use IDs for name lookup
+                if item["type"] == "assistant":
+                    for tool in item.get("tool_uses", []):
+                        tid = tool.get("tool_use_id")
+                        if tid:
+                            cache.tool_use_names[tid] = tool.get("name", "")
+                new_messages.append(item)
+
+        cache.messages.extend(new_messages)
+        return new_messages, len(cache.messages)
+
+    def clear_session(self, session_id: str) -> None:
+        """Remove cached state for a session (e.g. on restart)."""
+        self._cache.pop(session_id, None)

--- a/src/corral/static/app.js
+++ b/src/corral/static/app.js
@@ -16,6 +16,7 @@ import { loadAgentNotes, initNotesMd } from './agent_notes.js';
 import { switchAgenticTab, loadAgentEvents, toggleEventFilter, toggleAllEventFilters, showFilterPopup, hideFilterPopup } from './agentic_state.js';
 import { toggleHistoryEventFilter, toggleAllHistoryEventFilters } from './history_tabs.js';
 import { copyBranchName } from './utils.js';
+import { switchLiveView } from './live_chat.js';
 
 // ── Expose functions to HTML onclick handlers ─────────────────────────────
 window.sendCommand = sendCommand;
@@ -73,6 +74,7 @@ window.showFilterPopup = showFilterPopup;
 window.hideFilterPopup = hideFilterPopup;
 window.toggleHistoryEventFilter = toggleHistoryEventFilter;
 window.toggleAllHistoryEventFilters = toggleAllHistoryEventFilters;
+window.switchLiveView = switchLiveView;
 
 // ── History search/filter/pagination state ───────────────────────────────
 let historyPage = 1;
@@ -183,10 +185,15 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     });
 
-    // Auto-scroll detection for capture pane
+    // Auto-scroll detection for capture pane and live chat
     const capture = document.getElementById("pane-capture");
     capture.addEventListener("scroll", () => {
         const { scrollTop, scrollHeight, clientHeight } = capture;
+        state.autoScroll = (scrollHeight - scrollTop - clientHeight) < 50;
+    });
+    const liveChat = document.getElementById("live-chat-messages");
+    liveChat.addEventListener("scroll", () => {
+        const { scrollTop, scrollHeight, clientHeight } = liveChat;
         state.autoScroll = (scrollHeight - scrollTop - clientHeight) < 50;
     });
 

--- a/src/corral/static/live_chat.js
+++ b/src/corral/static/live_chat.js
@@ -1,0 +1,259 @@
+/* Live chat view — renders JSONL messages for live sessions */
+
+import { state } from './state.js';
+import { escapeHtml } from './utils.js';
+
+let chatPollInterval = null;
+let chatMessageCount = 0;
+
+function renderMarkdown(text) {
+    if (typeof marked !== 'undefined') {
+        try { return marked.parse(text); } catch (e) { /* fall through */ }
+    }
+    return escapeHtml(text);
+}
+
+const TOOL_ICONS = {
+    Read: "\u{1F4C4}",
+    Edit: "\u{270F}\uFE0F",
+    Write: "\u{1F4DD}",
+    Bash: "\u{1F4BB}",
+    Grep: "\u{1F50D}",
+    Glob: "\u{1F4C2}",
+    Agent: "\u{1F916}",
+    WebSearch: "\u{1F310}",
+    WebFetch: "\u{1F310}",
+    TaskCreate: "\u{2611}\uFE0F",
+    TaskUpdate: "\u{2611}\uFE0F",
+    NotebookEdit: "\u{1F4D3}",
+    AskUserQuestion: "\u{2753}",
+};
+
+function getToolIcon(name) {
+    return TOOL_ICONS[name] || "\u{1F527}";
+}
+
+function renderDiffLines(oldStr, newStr) {
+    const oldLines = oldStr.split("\n");
+    const newLines = newStr.split("\n");
+    let html = "";
+    for (const line of oldLines) {
+        html += `<div class="diff-line diff-del">- ${escapeHtml(line)}</div>`;
+    }
+    for (const line of newLines) {
+        html += `<div class="diff-line diff-add">+ ${escapeHtml(line)}</div>`;
+    }
+    return html;
+}
+
+/** Render inline output preview: first 3 lines visible, rest expandable */
+function renderInlineOutput(content, isError) {
+    const lines = content.split("\n");
+    const errorClass = isError ? " tool-result-error" : "";
+    const preview = lines.slice(0, 3).join("\n");
+
+    if (lines.length <= 3) {
+        return `<pre class="tool-output-inline${errorClass}">${escapeHtml(preview)}</pre>`;
+    }
+
+    const full = content;
+    return `<div class="tool-output-wrapper">
+        <pre class="tool-output-inline tool-output-collapsed${errorClass}">${escapeHtml(preview)}</pre>
+        <pre class="tool-output-inline tool-output-full${errorClass}" style="display:none">${escapeHtml(full)}</pre>
+        <button class="tool-output-toggle" onclick="this.parentElement.querySelector('.tool-output-collapsed').style.display='none';this.parentElement.querySelector('.tool-output-full').style.display='';this.textContent='';this.style.display='none'">... ${lines.length - 3} more lines</button>
+    </div>`;
+}
+
+function renderToolCard(tool) {
+    const icon = getToolIcon(tool.name);
+    const toolUseId = tool.tool_use_id || "";
+    let bodyHtml = "";
+
+    // Show description if present (Claude's prompt to the user)
+    if (tool.description) {
+        bodyHtml += `<div class="tool-card-description">${escapeHtml(tool.description)}</div>`;
+    }
+
+    if (tool.name === "Bash" && tool.command) {
+        // Bash: show full command in a code block
+        bodyHtml += `<pre class="tool-card-command">${escapeHtml(tool.command)}</pre>`;
+    } else if (tool.input_summary) {
+        bodyHtml += `<div class="tool-card-summary">${escapeHtml(tool.input_summary)}</div>`;
+    }
+
+    // AskUserQuestion: render structured question with options
+    if (tool.name === "AskUserQuestion" && tool.questions) {
+        for (const q of tool.questions) {
+            bodyHtml += `<div class="tool-question">`;
+            bodyHtml += `<div class="tool-question-text">${escapeHtml(q.question)}</div>`;
+            if (q.options && q.options.length > 0) {
+                bodyHtml += `<div class="tool-question-options">`;
+                for (const opt of q.options) {
+                    bodyHtml += `<div class="tool-question-option">`;
+                    bodyHtml += `<span class="tool-question-option-label">${escapeHtml(opt.label)}</span>`;
+                    if (opt.description) {
+                        bodyHtml += `<span class="tool-question-option-desc">${escapeHtml(opt.description)}</span>`;
+                    }
+                    bodyHtml += `</div>`;
+                }
+                bodyHtml += `</div>`;
+            }
+            bodyHtml += `</div>`;
+        }
+    }
+
+    // Edit tool: show diff
+    if (tool.name === "Edit" && (tool.old_string || tool.new_string)) {
+        const diffHtml = renderDiffLines(tool.old_string || "", tool.new_string || "");
+        bodyHtml += `<details class="tool-card-diff"><summary>Diff</summary><div class="diff-content">${diffHtml}</div></details>`;
+    }
+    // Write tool: show content preview
+    if (tool.name === "Write" && tool.write_content) {
+        bodyHtml += `<details class="tool-card-diff"><summary>Content</summary><pre class="tool-result-content">${escapeHtml(tool.write_content)}</pre></details>`;
+    }
+
+    return `<div class="tool-card" data-tool-use-id="${escapeHtml(toolUseId)}">
+        ${bodyHtml}
+    </div>`;
+}
+
+function renderMessage(msg, container) {
+    if (msg.type === "user") {
+        const div = document.createElement("div");
+        div.className = "chat-bubble human";
+        div.innerHTML = `
+            <div class="role-label">You</div>
+            <div class="message-text">${renderMarkdown(msg.content)}</div>
+        `;
+        container.appendChild(div);
+    } else if (msg.type === "assistant") {
+        const tools = msg.tool_uses || [];
+        const textHtml = msg.text ? `<div class="message-text">${renderMarkdown(msg.text)}</div>` : "";
+        if (tools.length > 0) {
+            // Text before tools (if any)
+            if (textHtml) {
+                const textDiv = document.createElement("div");
+                textDiv.className = "chat-bubble assistant";
+                textDiv.innerHTML = textHtml;
+                container.appendChild(textDiv);
+            }
+            // Each tool gets its own bubble with tool name as the role label
+            for (const tool of tools) {
+                const icon = getToolIcon(tool.name);
+                const toolDiv = document.createElement("div");
+                toolDiv.className = "chat-bubble assistant";
+                toolDiv.innerHTML = `<div class="role-label">${icon} ${escapeHtml(tool.name)}</div>` +
+                    renderToolCard(tool);
+                container.appendChild(toolDiv);
+            }
+        } else {
+            // Text-only assistant message
+            const div = document.createElement("div");
+            div.className = "chat-bubble assistant";
+            div.innerHTML = textHtml;
+            container.appendChild(div);
+        }
+    } else if (msg.type === "tool_result") {
+        // Inject output inline into the matching tool card
+        const toolUseId = msg.tool_use_id || "";
+        let targetCard = null;
+        if (toolUseId) {
+            targetCard = container.querySelector(`.tool-card[data-tool-use-id="${CSS.escape(toolUseId)}"]`);
+        }
+        if (targetCard) {
+            // Append inline output to the tool card
+            const outputDiv = document.createElement("div");
+            outputDiv.className = "tool-card-output";
+            outputDiv.innerHTML = renderInlineOutput(msg.content, msg.is_error);
+            targetCard.appendChild(outputDiv);
+        } else {
+            // Fallback: render as standalone block if no matching card found
+            const div = document.createElement("div");
+            div.className = "tool-result-block";
+            const toolName = msg.tool_name || "";
+            const icon = toolName ? getToolIcon(toolName) : "";
+            const label = toolName ? `${icon} ${escapeHtml(toolName)} Output` : "Output";
+            div.innerHTML = `<div class="tool-result-standalone">${label}</div>` +
+                renderInlineOutput(msg.content, msg.is_error);
+            container.appendChild(div);
+        }
+    }
+}
+
+export async function refreshLiveChat() {
+    if (!state.currentSession || state.currentSession.type !== "live") return;
+    if (state.liveViewMode !== "chat") return;
+
+    const session = state.currentSession;
+    if (!session.session_id) return;
+
+    try {
+        const params = new URLSearchParams();
+        params.set("session_id", session.session_id);
+        params.set("after", chatMessageCount);
+        if (session.working_directory) {
+            params.set("working_directory", session.working_directory);
+        }
+
+        const resp = await fetch(
+            `/api/sessions/live/${encodeURIComponent(session.name)}/chat?${params}`
+        );
+        const data = await resp.json();
+
+        if (!data.messages || data.messages.length === 0) return;
+
+        const container = document.getElementById("live-chat-messages");
+        for (const msg of data.messages) {
+            renderMessage(msg, container);
+        }
+        chatMessageCount = data.total;
+
+        if (state.autoScroll) {
+            container.scrollTop = container.scrollHeight;
+        }
+    } catch (e) {
+        console.error("Failed to refresh live chat:", e);
+    }
+}
+
+export function startLiveChatPoll() {
+    stopLiveChatPoll();
+    refreshLiveChat();
+    chatPollInterval = setInterval(refreshLiveChat, 1000);
+}
+
+export function stopLiveChatPoll() {
+    if (chatPollInterval) {
+        clearInterval(chatPollInterval);
+        chatPollInterval = null;
+    }
+}
+
+export function resetLiveChat() {
+    const container = document.getElementById("live-chat-messages");
+    if (container) container.innerHTML = "";
+    chatMessageCount = 0;
+}
+
+export function switchLiveView(mode) {
+    state.liveViewMode = mode;
+
+    const chatContainer = document.getElementById("live-chat-messages");
+    const termContainer = document.getElementById("pane-capture");
+    const btnChat = document.getElementById("btn-view-chat");
+    const btnTerm = document.getElementById("btn-view-terminal");
+
+    if (mode === "chat") {
+        chatContainer.style.display = "";
+        termContainer.style.display = "none";
+        btnChat.classList.add("active");
+        btnTerm.classList.remove("active");
+        startLiveChatPoll();
+    } else {
+        chatContainer.style.display = "none";
+        termContainer.style.display = "";
+        btnChat.classList.remove("active");
+        btnTerm.classList.add("active");
+        stopLiveChatPoll();
+    }
+}

--- a/src/corral/static/sessions.js
+++ b/src/corral/static/sessions.js
@@ -13,9 +13,11 @@ import { loadAgentTasks } from './tasks.js';
 import { loadAgentNotes } from './agent_notes.js';
 import { loadAgentEvents } from './agentic_state.js';
 import { loadHistoryEvents, loadHistoryTasks, loadHistoryAgentNotes } from './history_tabs.js';
+import { startLiveChatPoll, stopLiveChatPoll, resetLiveChat } from './live_chat.js';
 
 export async function selectLiveSession(name, agentType, sessionId) {
     stopCaptureRefresh();
+    stopLiveChatPoll();
 
     // Save current input text for the old session
     const input = document.getElementById("command-input");
@@ -24,13 +26,14 @@ export async function selectLiveSession(name, agentType, sessionId) {
         state.sessionInputText[oldKey] = input.value;
     }
 
-    // Look up display_name from live sessions data
+    // Look up display_name and working_directory from live sessions data
     const agentData = state.liveSessions.find(s => s.session_id === sessionId);
     const displayName = agentData ? agentData.display_name : null;
+    const workingDirectory = agentData ? agentData.working_directory : "";
 
     state.currentSession = {
         type: "live", name, agent_type: agentType || null, session_id: sessionId || null,
-        display_name: displayName || null,
+        display_name: displayName || null, working_directory: workingDirectory || "",
     };
 
     // Restore input text for the new session
@@ -77,8 +80,12 @@ export async function selectLiveSession(name, agentType, sessionId) {
     loadAgentNotes(name, sessionId);
     loadAgentEvents(name, sessionId);
 
-    // Start auto-refreshing capture
+    // Reset live chat and start appropriate polling
+    resetLiveChat();
     startCaptureRefresh();
+    if (state.liveViewMode === "chat") {
+        startLiveChatPoll();
+    }
 }
 
 export async function selectHistorySession(sessionId) {

--- a/src/corral/static/state.js
+++ b/src/corral/static/state.js
@@ -13,6 +13,7 @@ export const state = {
     currentAgentNotes: [],      // user notes for the currently selected live agent
     currentAgentEvents: [],     // events for the currently selected live agent
     eventFiltersHidden: null,   // Set of hidden filter keys (lazily initialized)
+    liveViewMode: "chat",       // "chat" or "terminal" — which live view to show
 };
 
 export function sessionKey(session) {

--- a/src/corral/static/style.css
+++ b/src/corral/static/style.css
@@ -885,8 +885,86 @@ body {
 }
 
 .chat-bubble .message-text {
-    white-space: pre-wrap;
     word-break: break-word;
+    line-height: 1.55;
+}
+
+.chat-bubble .message-text p {
+    margin: 4px 0;
+}
+
+.chat-bubble .message-text p:first-child {
+    margin-top: 0;
+}
+
+.chat-bubble .message-text p:last-child {
+    margin-bottom: 0;
+}
+
+.chat-bubble .message-text code {
+    background: rgba(255,255,255,0.07);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+    font-size: 12px;
+}
+
+.chat-bubble .message-text pre {
+    background: var(--bg-primary);
+    padding: 10px 12px;
+    border-radius: 6px;
+    overflow-x: auto;
+    margin: 8px 0;
+    border: 1px solid var(--border);
+}
+
+.chat-bubble .message-text pre code {
+    background: none;
+    padding: 0;
+    font-size: 12px;
+    line-height: 1.45;
+}
+
+.chat-bubble .message-text ul,
+.chat-bubble .message-text ol {
+    margin: 6px 0;
+    padding-left: 20px;
+}
+
+.chat-bubble .message-text li {
+    margin: 2px 0;
+}
+
+.chat-bubble .message-text h1,
+.chat-bubble .message-text h2,
+.chat-bubble .message-text h3 {
+    margin: 10px 0 4px;
+    font-size: 14px;
+    font-weight: 600;
+}
+
+.chat-bubble .message-text blockquote {
+    border-left: 3px solid var(--accent);
+    padding-left: 10px;
+    margin: 6px 0;
+    color: var(--text-secondary);
+}
+
+.chat-bubble .message-text table {
+    border-collapse: collapse;
+    margin: 8px 0;
+    font-size: 12px;
+}
+
+.chat-bubble .message-text th,
+.chat-bubble .message-text td {
+    border: 1px solid var(--border);
+    padding: 4px 8px;
+}
+
+.chat-bubble .message-text th {
+    background: var(--bg-secondary);
+    font-weight: 600;
 }
 
 .chat-bubble .edit-btn {
@@ -911,6 +989,253 @@ body {
 .chat-bubble .edit-btn:hover {
     background: var(--accent-dim);
     color: var(--text-primary);
+}
+
+/* Live View Toggle */
+.live-view-toggle {
+    display: inline-flex;
+    gap: 0;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    overflow: hidden;
+    margin-left: auto;
+    flex-shrink: 0;
+}
+
+.live-view-btn {
+    padding: 3px 12px;
+    font-size: 12px;
+    font-weight: 500;
+    background: var(--bg-secondary);
+    color: var(--text-secondary);
+    border: none;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+}
+
+.live-view-btn:first-child {
+    border-right: 1px solid var(--border);
+}
+
+.live-view-btn.active {
+    background: var(--accent);
+    color: #fff;
+}
+
+.live-view-btn:hover:not(.active) {
+    background: var(--bg-hover);
+}
+
+/* Live Chat View */
+.live-chat-view {
+    flex: 1;
+    overflow-y: auto;
+    padding: 16px 20px;
+}
+
+/* Tool Cards */
+.tool-card {
+    margin-top: 6px;
+    padding: 6px 10px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg-secondary);
+    font-size: 12px;
+}
+
+/* Tool name now rendered as .role-label on the bubble */
+
+.tool-card-summary {
+    margin-top: 3px;
+    color: var(--text-muted);
+    font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+    font-size: 11px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 100%;
+}
+
+.tool-card-description {
+    color: var(--text-primary);
+    font-size: 12px;
+    margin-bottom: 4px;
+}
+
+/* AskUserQuestion prompt */
+.tool-question {
+    margin-top: 4px;
+}
+
+.tool-question-text {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-primary);
+    margin-bottom: 6px;
+}
+
+.tool-question-options {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.tool-question-option {
+    display: flex;
+    flex-direction: column;
+    padding: 6px 10px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg-primary);
+}
+
+.tool-question-option-label {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--accent);
+}
+
+.tool-question-option-desc {
+    font-size: 11px;
+    color: var(--text-muted);
+    margin-top: 2px;
+}
+
+.tool-card-command {
+    margin: 3px 0 0;
+    padding: 6px 8px;
+    background: var(--bg-primary);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+    font-size: 11px;
+    line-height: 1.4;
+    color: var(--text-primary);
+    white-space: pre-wrap;
+    word-break: break-all;
+    overflow-x: auto;
+}
+
+/* Tool Card Diff */
+.tool-card-diff {
+    margin-top: 4px;
+    font-size: 11px;
+}
+
+.tool-card-diff > summary {
+    cursor: pointer;
+    color: var(--text-muted);
+    font-size: 11px;
+    user-select: none;
+    padding: 2px 0;
+}
+
+.tool-card-diff > summary:hover {
+    color: var(--text-secondary);
+}
+
+.diff-content {
+    margin-top: 4px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg-primary);
+    overflow-x: auto;
+    max-height: 300px;
+    overflow-y: auto;
+    font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+}
+
+.diff-line {
+    padding: 0 8px;
+    white-space: pre-wrap;
+    word-break: break-all;
+    line-height: 1.4;
+}
+
+.diff-line.diff-del {
+    background: rgba(248, 81, 73, 0.15);
+    color: #f85149;
+}
+
+.diff-line.diff-add {
+    background: rgba(63, 185, 80, 0.15);
+    color: #3fb950;
+}
+
+/* Tool Result Output Blocks */
+/* Tool result content (used inside collapsible details in tool cards) */
+.tool-result-content {
+    margin: 0;
+    padding: 8px 10px;
+    border-top: 1px solid var(--border);
+    font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+    font-size: 11px;
+    line-height: 1.4;
+    color: var(--text-secondary);
+    overflow-x: auto;
+    max-height: 400px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+}
+
+/* Inline output inside tool cards */
+.tool-card-output {
+    border-top: 1px solid var(--border);
+    margin-top: 6px;
+    padding-top: 4px;
+}
+
+.tool-output-inline {
+    margin: 0;
+    padding: 4px 8px;
+    font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+    font-size: 11px;
+    line-height: 1.4;
+    color: var(--text-secondary);
+    white-space: pre-wrap;
+    word-break: break-all;
+    max-height: 300px;
+    overflow-y: auto;
+    overflow-x: auto;
+}
+
+.tool-output-toggle {
+    display: block;
+    background: none;
+    border: none;
+    color: var(--accent);
+    font-size: 11px;
+    cursor: pointer;
+    padding: 2px 8px 4px;
+    opacity: 0.8;
+}
+
+.tool-output-toggle:hover {
+    opacity: 1;
+    text-decoration: underline;
+}
+
+.tool-output-inline.tool-result-error {
+    color: var(--error);
+    opacity: 0.85;
+}
+
+/* Fallback standalone result block (when no matching card) */
+.tool-result-block {
+    max-width: 85%;
+    margin-bottom: 4px;
+    margin-top: -12px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 6px;
+}
+
+.tool-result-standalone {
+    font-size: 11px;
+    color: var(--text-muted);
+    margin-bottom: 4px;
 }
 
 /* Buttons */

--- a/src/corral/templates/index.html
+++ b/src/corral/templates/index.html
@@ -83,12 +83,17 @@
                         <div id="session-status" class="status-line">
                             <strong>Status:</strong> <span class="status-text">Idle</span>
                         </div>
+                        <div class="live-view-toggle">
+                            <button class="live-view-btn active" id="btn-view-chat" onclick="switchLiveView('chat')">Chat</button>
+                            <button class="live-view-btn" id="btn-view-terminal" onclick="switchLiveView('terminal')">Terminal</button>
+                        </div>
                     </div>
                 </div>
 
                 <div class="live-body">
                     <div class="live-left-column">
-                        <div id="pane-capture" class="output-scroll capture-text"></div>
+                        <div id="live-chat-messages" class="chat-messages live-chat-view"></div>
+                        <div id="pane-capture" class="output-scroll capture-text" style="display:none"></div>
                         <div class="command-pane-resize-handle" id="command-pane-resize-handle"></div>
                         <div class="command-pane" id="command-pane">
                             <div class="command-pane-toolbar" id="command-toolbar">


### PR DESCRIPTION
Adds a Chat/Terminal toggle to live sessions that renders the agent's JSONL transcript as a structured chat view with tool cards, inline output, diffs, and markdown rendering. Each tool gets its own bubble with the tool name as a role label, Bash commands render in code blocks, and tool results are inlined with expandable 3-line previews.

- New jsonl_reader.py backend: incremental JSONL parser with byte-offset caching, tool_use_id→name mapping, and 10K char result limit
- New live_chat.js frontend: chat renderer with marked.js markdown, tool cards, diff views, and inline expandable output
- API endpoint /api/sessions/live/{name}/chat for polling new messages
- Chat/Terminal toggle with independent scroll and auto-scroll detection
- Terminal capture only fetches in terminal mode to reduce server load