### PR TITLE
feat: add folder tags for sidebar session groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 site/
 .venv/*
 .claude/scheduled_tasks.lock
+.claude/settings.local.json

--- a/src/coral/api/system.py
+++ b/src/coral/api/system.py
@@ -106,3 +106,34 @@ async def delete_tag(tag_id: int):
     """Delete a tag."""
     await store.delete_tag(tag_id)
     return {"ok": True}
+
+
+# ── Folder Tags ────────────────────────────────────────────────────────
+
+@router.get("/api/folder-tags")
+async def get_all_folder_tags():
+    """Return all folder tags as {folder_name: [tags...]}."""
+    return await store.get_all_folder_tags()
+
+
+@router.get("/api/folder-tags/{folder_name}")
+async def get_folder_tags(folder_name: str):
+    """Return tags for a specific folder."""
+    return await store.get_folder_tags(folder_name)
+
+
+@router.post("/api/folder-tags/{folder_name}")
+async def add_folder_tag(folder_name: str, body: dict):
+    """Add a tag to a folder."""
+    tag_id = body.get("tag_id")
+    if not tag_id:
+        return {"error": "tag_id is required"}
+    await store.add_folder_tag(folder_name, int(tag_id))
+    return {"ok": True}
+
+
+@router.delete("/api/folder-tags/{folder_name}/{tag_id}")
+async def remove_folder_tag(folder_name: str, tag_id: int):
+    """Remove a tag from a folder."""
+    await store.remove_folder_tag(folder_name, tag_id)
+    return {"ok": True}

--- a/src/coral/static/app.js
+++ b/src/coral/static/app.js
@@ -33,6 +33,7 @@ import {
 import { initLiveJobs, renderLiveJobs, selectLiveJobRun } from './live_jobs.js';
 import { showThemeConfigurator, hideThemeConfigurator } from './theme_config.js';
 import { initMessageBoard, selectBoardProject, showMessageBoardProjects, postBoardMessage, deleteMessageBoardProject, toggleBoardPause, deleteBoardMessage } from './message_board.js';
+import { loadAllFolderTags, showFolderTagDropdown, hideFolderTagDropdown, addFolderTag, removeFolderTag, createAndAddFolderTag } from './folder_tags.js';
 
 import { checkForUpdates, dismissUpdateToast } from './update_check.js';
 
@@ -134,6 +135,11 @@ window.postBoardMessage = postBoardMessage;
 window.deleteMessageBoardProject = deleteMessageBoardProject;
 window.toggleBoardPause = toggleBoardPause;
 window.deleteBoardMessage = deleteBoardMessage;
+window.showFolderTagDropdown = showFolderTagDropdown;
+window.hideFolderTagDropdown = hideFolderTagDropdown;
+window.addFolderTag = addFolderTag;
+window.removeFolderTag = removeFolderTag;
+window.createAndAddFolderTag = createAndAddFolderTag;
 
 // ── Sidebar kebab menu helpers ───────────────────────────────────────────
 function closeSidebarKebabs() {
@@ -285,6 +291,7 @@ document.addEventListener("DOMContentLoaded", () => {
     historyPage = restored.page;
 
     loadLiveSessions();
+    loadAllFolderTags();
     connectCoralWs();
     checkForUpdates();
     populateHfTagSelect().then(() => {

--- a/src/coral/static/css/components.css
+++ b/src/coral/static/css/components.css
@@ -772,6 +772,29 @@
     margin: 0;
 }
 
+/* ── Folder Tag Dropdown ──────────────────────────────────── */
+
+.folder-tag-dropdown {
+    position: fixed;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 12px;
+    z-index: 100;
+    min-width: 200px;
+    max-width: 280px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+}
+
+.folder-tag-current {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 8px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--border);
+}
+
 /* ── Pagination Controls ───────────────────────────────────── */
 
 .pagination-controls {

--- a/src/coral/static/css/session.css
+++ b/src/coral/static/css/session.css
@@ -381,6 +381,49 @@
     line-height: 16px;
 }
 
+.session-group-name {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.folder-tag-full {
+    font-size: 9px;
+    font-weight: 500;
+    color: #fff;
+    padding: 1px 6px;
+    border-radius: 8px;
+    line-height: 14px;
+    white-space: nowrap;
+    text-transform: none;
+    letter-spacing: 0;
+}
+
+.session-group-spacer {
+    flex: 1;
+}
+
+.folder-tag-btn {
+    display: none;
+    font-size: 11px;
+    cursor: pointer;
+    color: var(--text-muted);
+    padding: 0 4px;
+    border-radius: 3px;
+    background: none;
+    border: none;
+    line-height: 1;
+}
+
+.folder-tag-btn:hover {
+    color: var(--text-primary);
+    background: var(--bg-hover);
+}
+
+.session-group-header:hover .folder-tag-btn {
+    display: inline-block;
+}
+
 .session-group-item {
     padding-left: 33px !important;
     cursor: grab;

--- a/src/coral/static/folder_tags.js
+++ b/src/coral/static/folder_tags.js
@@ -1,0 +1,205 @@
+/* Folder-level tags: load, render, dropdown picker, add/remove */
+
+import { state } from './state.js';
+import { escapeHtml, escapeAttr, showToast } from './utils.js';
+import { renderLiveSessions } from './render.js';
+import { loadAllTags } from './tags.js';
+
+let allFolderTags = {};
+
+export async function loadAllFolderTags() {
+    try {
+        const resp = await fetch("/api/folder-tags");
+        allFolderTags = await resp.json();
+    } catch (e) {
+        console.error("Failed to load folder tags:", e);
+        allFolderTags = {};
+    }
+}
+
+export function getFolderTags(folderName) {
+    return allFolderTags[folderName] || [];
+}
+
+export function renderFolderTagPills(tags) {
+    if (!tags || tags.length === 0) return "";
+    if (tags.length <= 2) {
+        return tags.map(t =>
+            `<span class="folder-tag-full" style="background:${escapeHtml(t.color)}">${escapeHtml(t.name)}</span>`
+        ).join("");
+    }
+    return '<span class="sidebar-tag-pills">' +
+        tags.map(t => `<span class="sidebar-tag-pill" style="background:${escapeHtml(t.color)}" title="${escapeHtml(t.name)}"></span>`).join("") +
+        '</span>';
+}
+
+export async function showFolderTagDropdown(folderName, anchorEl) {
+    hideFolderTagDropdown();
+    await loadAllTags();
+
+    const rect = anchorEl.getBoundingClientRect();
+    const dropdown = document.createElement("div");
+    dropdown.className = "folder-tag-dropdown";
+    dropdown.id = "folder-tag-dropdown";
+    dropdown.style.left = (rect.right + 8) + "px";
+    dropdown.style.top = rect.top + "px";
+
+    const tags = getFolderTags(folderName);
+    dropdown.innerHTML = _buildDropdownHtml(folderName, tags);
+    document.body.appendChild(dropdown);
+
+    // Reposition if overflows viewport bottom
+    const ddRect = dropdown.getBoundingClientRect();
+    if (ddRect.bottom > window.innerHeight - 8) {
+        dropdown.style.top = Math.max(8, window.innerHeight - ddRect.height - 8) + "px";
+    }
+
+    // Close on outside click
+    setTimeout(() => {
+        document.addEventListener("click", _onOutsideClick);
+    }, 0);
+}
+
+function _onOutsideClick(e) {
+    const dd = document.getElementById("folder-tag-dropdown");
+    if (dd && !dd.contains(e.target)) {
+        hideFolderTagDropdown();
+    }
+}
+
+export function hideFolderTagDropdown() {
+    const dd = document.getElementById("folder-tag-dropdown");
+    if (dd) dd.remove();
+    document.removeEventListener("click", _onOutsideClick);
+}
+
+function _buildDropdownHtml(folderName, currentTags) {
+    const escapedFolder = escapeAttr(folderName);
+
+    let currentHtml = "";
+    if (currentTags.length > 0) {
+        currentHtml = `<div class="folder-tag-current">${currentTags.map(t =>
+            `<span class="tag-pill" style="background:${escapeHtml(t.color)}">
+                ${escapeHtml(t.name)}
+                <span class="tag-remove" onclick="event.stopPropagation(); removeFolderTag('${escapedFolder}', ${t.id})">&times;</span>
+            </span>`
+        ).join("")}</div>`;
+    }
+
+    // Get all available tags from the tags module cache
+    const allTags = _getAllTagsFromCache();
+    const currentIds = new Set(currentTags.map(t => t.id));
+    const available = allTags.filter(t => !currentIds.has(t.id));
+
+    let availableHtml = "";
+    if (available.length > 0) {
+        availableHtml = `<div class="tag-dropdown-list">${available.map(t =>
+            `<span class="tag-dropdown-item" style="background:${escapeHtml(t.color)}"
+                  onclick="event.stopPropagation(); addFolderTag('${escapedFolder}', ${t.id})">
+                ${escapeHtml(t.name)}
+            </span>`
+        ).join("")}</div>`;
+    } else {
+        availableHtml = '<div class="tag-dropdown-list"><span style="font-size:12px;color:var(--text-muted)">No tags available</span></div>';
+    }
+
+    const createHtml = `<div class="tag-dropdown-create">
+        <input type="text" id="folder-tag-new-name" placeholder="New tag name" onkeydown="if(event.key==='Enter'){event.stopPropagation(); createAndAddFolderTag('${escapedFolder}')}" />
+        <input type="color" id="folder-tag-new-color" value="#58a6ff" />
+        <button class="btn btn-small" onclick="event.stopPropagation(); createAndAddFolderTag('${escapedFolder}')">Add</button>
+    </div>`;
+
+    return `<div class="tag-dropdown-header">Folder Tags</div>
+        ${currentHtml}
+        ${availableHtml}
+        ${createHtml}`;
+}
+
+function _getAllTagsFromCache() {
+    // Access the allTags array from the tags module via a fetch-if-needed approach
+    // Since loadAllTags was called in showFolderTagDropdown, we rely on the DOM-based
+    // approach or re-fetch. For simplicity, we use a synchronous fetch from the module.
+    return window._allTagsCache || [];
+}
+
+export async function addFolderTag(folderName, tagId) {
+    try {
+        const resp = await fetch(`/api/folder-tags/${encodeURIComponent(folderName)}`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ tag_id: tagId }),
+        });
+        const result = await resp.json();
+        if (result.error) {
+            showToast(result.error, true);
+            return;
+        }
+        await loadAllFolderTags();
+        renderLiveSessions(state.liveSessions);
+        // Re-open dropdown to show updated state
+        const header = _findGroupHeader(folderName);
+        if (header) await showFolderTagDropdown(folderName, header);
+        showToast("Tag added");
+    } catch (e) {
+        showToast("Failed to add tag", true);
+    }
+}
+
+export async function removeFolderTag(folderName, tagId) {
+    try {
+        const resp = await fetch(`/api/folder-tags/${encodeURIComponent(folderName)}/${tagId}`, {
+            method: "DELETE",
+        });
+        const result = await resp.json();
+        if (result.error) {
+            showToast(result.error, true);
+            return;
+        }
+        await loadAllFolderTags();
+        renderLiveSessions(state.liveSessions);
+        // Re-open dropdown to show updated state
+        const header = _findGroupHeader(folderName);
+        if (header) await showFolderTagDropdown(folderName, header);
+        showToast("Tag removed");
+    } catch (e) {
+        showToast("Failed to remove tag", true);
+    }
+}
+
+export async function createAndAddFolderTag(folderName) {
+    const nameInput = document.getElementById("folder-tag-new-name");
+    const colorInput = document.getElementById("folder-tag-new-color");
+    const name = nameInput ? nameInput.value.trim() : "";
+    const color = colorInput ? colorInput.value : "#58a6ff";
+
+    if (!name) {
+        showToast("Tag name is required", true);
+        return;
+    }
+
+    try {
+        const resp = await fetch("/api/tags", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ name, color }),
+        });
+        const result = await resp.json();
+        if (result.error) {
+            showToast(result.error, true);
+            return;
+        }
+        // Now add the new tag to this folder
+        await addFolderTag(folderName, result.id);
+    } catch (e) {
+        showToast("Failed to create tag", true);
+    }
+}
+
+function _findGroupHeader(folderName) {
+    const headers = document.querySelectorAll(".session-group-header");
+    for (const h of headers) {
+        const nameEl = h.querySelector(".session-group-name");
+        if (nameEl && nameEl.textContent.trim().startsWith(folderName)) return h;
+    }
+    return null;
+}

--- a/src/coral/static/render.js
+++ b/src/coral/static/render.js
@@ -1,8 +1,9 @@
 /* Rendering functions for session lists, chat history, and status updates */
 
 import { state } from './state.js';
-import { escapeHtml, showToast } from './utils.js';
+import { escapeHtml, showToast, escapeAttr } from './utils.js';
 import { renderSidebarTagDots } from './tags.js';
+import { getFolderTags, renderFolderTagPills } from './folder_tags.js';
 import { updateSectionVisibility } from './sidebar.js';
 
 function formatShortTime(isoStr) {
@@ -309,8 +310,11 @@ export function renderLiveSessions(sessions) {
         </div>`;
         const groupBranch = sorted.find(s => s.branch)?.branch || "";
         const groupBranchLine = groupBranch ? `<div class="group-branch-line"><svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 3v5a3 3 0 0 0 3 3h1"/><circle cx="6" cy="3" r="1.5"/><circle cx="11" cy="11" r="1.5"/></svg> ${escapeHtml(groupBranch)}</div>` : "";
+        const fTags = getFolderTags(groupName);
+        const tagDots = renderFolderTagPills(fTags);
+        const tagBtn = `<button class="folder-tag-btn" onclick="event.stopPropagation(); showFolderTagDropdown('${escapeAttr(groupName)}', this.closest('.session-group-header'))" title="Manage tags">+</button>`;
         html += `<li class="session-group-header" data-group-name="${escapeHtml(groupName)}" onclick="toggleGroupCollapse('${escapeHtml(groupName)}')">
-            <span class="group-chevron">${chevron}</span><div class="group-header-text"><div class="group-name-line">${escapeHtml(groupName)}${countBadge}</div>${groupBranchLine}</div><span class="session-name-spacer"></span>${groupKebab}</li>`;
+            <span class="group-chevron">${chevron}</span><div class="group-header-text"><div class="group-name-line">${escapeHtml(groupName)}${countBadge}</div>${groupBranchLine}</div>${tagDots}<span class="session-name-spacer"></span>${tagBtn}${groupKebab}</li>`;
 
         if (collapsed) {
             // Skip rendering items when collapsed

--- a/src/coral/static/tags.js
+++ b/src/coral/static/tags.js
@@ -15,6 +15,9 @@ export async function loadAllTags() {
         console.error("Failed to load tags:", e);
         allTags = [];
     }
+    // Expose cache for cross-module access (folder_tags.js)
+    window._allTagsCache = allTags;
+    return allTags;
 }
 
 export async function loadSessionTags(sessionId) {

--- a/src/coral/store/connection.py
+++ b/src/coral/store/connection.py
@@ -63,6 +63,13 @@ class DatabaseManager:
                 FOREIGN KEY (tag_id) REFERENCES tags(id) ON DELETE CASCADE
             );
 
+            CREATE TABLE IF NOT EXISTS folder_tags (
+                folder_name TEXT NOT NULL,
+                tag_id      INTEGER NOT NULL,
+                PRIMARY KEY (folder_name, tag_id),
+                FOREIGN KEY (tag_id) REFERENCES tags(id) ON DELETE CASCADE
+            );
+
             CREATE TABLE IF NOT EXISTS session_index (
                 session_id      TEXT PRIMARY KEY,
                 source_type     TEXT NOT NULL,
@@ -319,6 +326,7 @@ class DatabaseManager:
         for ddl in [
             "CREATE INDEX IF NOT EXISTS idx_git_snap_session ON git_snapshots(session_id)",
             "CREATE INDEX IF NOT EXISTS idx_session_tags_tag_id ON session_tags(tag_id)",
+            "CREATE INDEX IF NOT EXISTS idx_folder_tags_tag_id ON folder_tags(tag_id)",
             "CREATE INDEX IF NOT EXISTS idx_session_index_first_ts ON session_index(first_timestamp)",
             # Performance indexes for frequent queries
             "CREATE INDEX IF NOT EXISTS idx_agent_events_session ON agent_events(session_id)",

--- a/src/coral/store/sessions.py
+++ b/src/coral/store/sessions.py
@@ -245,6 +245,47 @@ class SessionStore(DatabaseManager):
         )
         await conn.commit()
 
+    # ── Folder Tags ───────────────────────────────────────────────────────
+
+    async def get_folder_tags(self, folder_name: str) -> list[dict[str, Any]]:
+        conn = await self._get_conn()
+        rows = await (await conn.execute(
+            "SELECT t.id, t.name, t.color FROM tags t "
+            "JOIN folder_tags ft ON ft.tag_id = t.id WHERE ft.folder_name = ? ORDER BY t.name",
+            (folder_name,),
+        )).fetchall()
+        return [dict(r) for r in rows]
+
+    async def add_folder_tag(self, folder_name: str, tag_id: int) -> None:
+        conn = await self._get_conn()
+        await conn.execute(
+            "INSERT OR IGNORE INTO folder_tags (folder_name, tag_id) VALUES (?, ?)",
+            (folder_name, tag_id),
+        )
+        await conn.commit()
+
+    async def remove_folder_tag(self, folder_name: str, tag_id: int) -> None:
+        conn = await self._get_conn()
+        await conn.execute(
+            "DELETE FROM folder_tags WHERE folder_name = ? AND tag_id = ?",
+            (folder_name, tag_id),
+        )
+        await conn.commit()
+
+    async def get_all_folder_tags(self) -> dict[str, list[dict[str, Any]]]:
+        """Return {folder_name: [{id, name, color}, ...]} for all folder tags."""
+        conn = await self._get_conn()
+        rows = await (await conn.execute(
+            "SELECT ft.folder_name, t.id, t.name, t.color FROM folder_tags ft "
+            "JOIN tags t ON t.id = ft.tag_id ORDER BY t.name"
+        )).fetchall()
+        result: dict[str, list[dict[str, Any]]] = {}
+        for r in rows:
+            result.setdefault(r["folder_name"], []).append({
+                "id": r["id"], "name": r["name"], "color": r["color"],
+            })
+        return result
+
     # ── Session Index ──────────────────────────────────────────────────────
 
     async def upsert_session_index(


### PR DESCRIPTION
## Summary
- Adds a new `folder_tags` table to associate tags with sidebar folder groups
- New API endpoints: `GET/POST/DELETE /api/folder-tags/{folder_name}`
- Dropdown picker on each group header to add/remove/create tags
- Shows full tag pills for 1-2 tags, color dots for 3+
- Reuses the existing tag system (shared `tags` table with cascade delete)

## Test plan

https://www.loom.com/share/b337f022591e452ca731ec35ae7fa2d8

<img width="411" height="572" alt="image" src="https://github.com/user-attachments/assets/3cf56ca1-3d7a-474a-ac0a-3d1014f8dfef" />
