### PR TITLE
fix: improve agentic state hooks and session dot UI

### DIFF
--- a/src/coral/agents/claude.py
+++ b/src/coral/agents/claude.py
@@ -49,6 +49,13 @@ _CORAL_HOOKS = [
     ("Notification", {
         "hooks": [{"type": "command", "command": "coral-hook-agentic-state"}],
     }),
+    ("UserPromptSubmit", {
+        "hooks": [{"type": "command", "command": "coral-hook-agentic-state"}],
+    }),
+    ("SessionStart", {
+        "matcher": "clear",
+        "hooks": [{"type": "command", "command": "coral-hook-agentic-state --session-clear"}],
+    }),
 ]
 
 
@@ -270,6 +277,32 @@ class ClaudeAgent(BaseAgent):
         """Parse a Claude hook payload into an agentic event for the dashboard."""
         session_id = resolve_session_id(hook_data.get("session_id"))
         hook_type = hook_data.get("hook_event_name") or hook_data.get("type", "")
+
+        # SessionStart with source="clear" fires when the user runs /clear.
+        # The --session-clear CLI arg injects _coral_session_clear into hook_data
+        # as a fallback when hook_event_name isn't set.
+        if hook_type == "SessionStart" or hook_data.get("_coral_session_clear"):
+            return {
+                "event_type": "session_reset",
+                "tool_name": None,
+                "summary": "Session reset: /clear",
+                "session_id": session_id,
+            }
+
+        # UserPromptSubmit: fall back to detecting the "prompt" field when
+        # hook_event_name isn't populated.  Guard against tool_use / stop
+        # payloads that might also contain a "prompt" key.
+        if hook_type == "UserPromptSubmit" or (
+            "prompt" in hook_data
+            and not hook_data.get("tool_name")
+            and not hook_data.get("stop_hook_active")
+        ):
+            return {
+                "event_type": "prompt_submit",
+                "tool_name": None,
+                "summary": "User submitted prompt",
+                "session_id": session_id,
+            }
 
         tool = hook_data.get("tool_name", "")
         inp = hook_data.get("tool_input", {}) if isinstance(hook_data.get("tool_input"), dict) else {}

--- a/src/coral/api/live_sessions.py
+++ b/src/coral/api/live_sessions.py
@@ -134,8 +134,12 @@ async def _build_session_list(include_commands: bool = False) -> list[dict]:
         ev_tuple = latest_events.get(sid) if sid else None
         latest_ev = ev_tuple[0] if ev_tuple else None
         ev_summary = ev_tuple[1] if ev_tuple else None
-        waiting = latest_ev in ("stop", "notification")
-        working = latest_ev == "tool_use" and (log_info["staleness_seconds"] or 999) < 120
+        needs_input = latest_ev == "notification"
+        done = latest_ev == "stop"
+        working = latest_ev in ("tool_use", "prompt_submit")
+        stuck = working and (log_info["staleness_seconds"] or 999) > 420
+        if stuck:
+            working = False
 
         summary = log_info["summary"]
         if not summary and sid:
@@ -156,10 +160,12 @@ async def _build_session_list(include_commands: bool = False) -> list[dict]:
             "branch": git["branch"] if git else None,
             "display_name": display_names.get(sid) if sid else None,
             "working_directory": agent.get("working_directory", ""),
-            "waiting_for_input": waiting,
-            "waiting_reason": latest_ev if waiting else None,
-            "waiting_summary": ev_summary if waiting else None,
+            "waiting_for_input": needs_input,
+            "done": done,
             "working": working,
+            "stuck": stuck,
+            "waiting_reason": latest_ev if needs_input else None,
+            "waiting_summary": ev_summary if needs_input else None,
             "changed_file_count": fc,
             "board_project": board_sub["project"] if board_sub else None,
             "board_job_title": board_sub["job_title"] if board_sub else None,

--- a/src/coral/background_tasks/idle_detector.py
+++ b/src/coral/background_tasks/idle_detector.py
@@ -49,7 +49,7 @@ class IdleDetector:
             sid = agent.get("session_id")
             ev_tuple = latest_events.get(sid) if sid else None
             latest_ev = ev_tuple[0] if ev_tuple else None
-            waiting = latest_ev in ("stop", "notification")
+            waiting = latest_ev == "notification"
 
             if not waiting:
                 # Agent is active — clear notification state

--- a/src/coral/hooks/agentic_state.py
+++ b/src/coral/hooks/agentic_state.py
@@ -17,11 +17,26 @@ def main():
     """Read hook JSON from stdin, create event for the activity timeline."""
     try:
         raw = sys.stdin.read()
-        d = json.loads(raw)
-    except (json.JSONDecodeError, ValueError):
+    except Exception as exc:
+        debug_log(f"AGENTIC_STATE STDIN_ERROR: {type(exc).__name__}: {exc}")
         return
 
-    debug_log(f"AGENTIC_STATE INPUT: {raw[:500]}")
+    debug_log(f"AGENTIC_STATE RAW({len(raw)}): {raw[:300]}")
+
+    try:
+        d = json.loads(raw)
+    except (json.JSONDecodeError, ValueError) as exc:
+        debug_log(f"AGENTIC_STATE JSON_ERROR: {exc}")
+        return
+
+    # If launched with --session-clear, inject a marker so parse_agentic_event
+    # can identify this as a SessionStart/clear event even when
+    # hook_event_name is missing from the payload.
+    if "--session-clear" in sys.argv:
+        d["_coral_session_clear"] = True
+
+    hook_type = d.get("hook_event_name") or d.get("type", "")
+    debug_log(f"AGENTIC_STATE INPUT: hook_type={hook_type} argv={sys.argv[1:]}")
 
     port = os.environ.get("CORAL_PORT", "8420")
     base = f"http://localhost:{port}"
@@ -32,11 +47,12 @@ def main():
 
     agent_name = agent.resolve_agent_name(d)
     if not agent_name:
+        debug_log(f"DROPPED (no agent_name): hook_type={hook_type}")
         return
 
     event = agent.parse_agentic_event(d)
     if event is None:
-        debug_log(f"DONE (no event): agent={agent_name}")
+        debug_log(f"DROPPED (parse returned None): hook_type={hook_type} agent={agent_name} keys={list(d.keys())}")
         return
 
     # Send event to the Coral dashboard

--- a/src/coral/hooks/utils.py
+++ b/src/coral/hooks/utils.py
@@ -56,12 +56,20 @@ def cache_dir() -> str:
 
 
 def debug_log(msg: str) -> None:
-    """Append to debug log if CORAL_HOOK_DEBUG is set."""
-    if not os.environ.get("CORAL_HOOK_DEBUG"):
-        return
+    """Append a timestamped line to the hook debug log."""
     try:
-        with open(os.path.join(cache_dir(), "debug.log"), "a") as f:
-            f.write(msg + "\n")
+        log_path = os.path.join(cache_dir(), "debug.log")
+        # Rotate: truncate if over 500KB
+        try:
+            if os.path.getsize(log_path) > 512_000:
+                with open(log_path, "w") as f:
+                    f.write("--- log rotated ---\n")
+        except OSError:
+            pass
+        from datetime import datetime, timezone
+        ts = datetime.now(timezone.utc).strftime("%H:%M:%S.%f")[:-3]
+        with open(log_path, "a") as f:
+            f.write(f"[{ts}] {msg}\n")
     except OSError:
         pass
 

--- a/src/coral/static/css/animations.css
+++ b/src/coral/static/css/animations.css
@@ -12,6 +12,11 @@
     50%      { opacity: 0.6; box-shadow: 0 0 0 4px rgba(255, 193, 7, 0); }
 }
 
+@keyframes pulse-stuck {
+    0%, 100% { opacity: 1; box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.3); }
+    50%      { opacity: 0.85; box-shadow: 0 0 0 3px rgba(239, 68, 68, 0); }
+}
+
 @keyframes pulse {
     0%, 100% { opacity: 0.4; }
     50%      { opacity: 1; }

--- a/src/coral/static/css/session.css
+++ b/src/coral/static/css/session.css
@@ -85,7 +85,6 @@
     margin-top: 5px;
 }
 
-.session-dot.active  { background: var(--success); }
 .session-dot.stale   { background: var(--text-muted); }
 .session-dot.working {
     background: #3b82f6;
@@ -97,6 +96,10 @@
 }
 .session-dot.done {
     background: var(--success, #4caf50);
+}
+.session-dot.stuck {
+    background: var(--danger, #ef4444);
+    animation: pulse-stuck 3s ease-in-out infinite;
 }
 
 /* ── Session Hover Tooltip ─────────────────────────────────── */
@@ -138,9 +141,10 @@
 }
 
 .tt-state-working           { color: #3b82f6; font-weight: 600; }
-.tt-state-waiting-for-input  { color: var(--warning); font-weight: 600; }
-.tt-state-active             { color: var(--success); font-weight: 600; }
-.tt-state-idle               { color: var(--text-muted); }
+.tt-state-needs-input       { color: var(--warning); font-weight: 600; }
+.tt-state-done              { color: var(--success); font-weight: 600; }
+.tt-state-stuck             { color: var(--danger, #ef4444); font-weight: 600; }
+.tt-state-idle              { color: var(--text-muted); }
 .tt-unread                   { color: var(--warning); font-weight: 600; }
 
 .session-time {
@@ -649,6 +653,11 @@
 
 .status-dot.done {
     background: var(--success, #4caf50);
+}
+
+.status-dot.stuck {
+    background: var(--danger, #ef4444);
+    animation: pulse-stuck 3s ease-in-out infinite;
 }
 
 .status-dot-stale {

--- a/src/coral/static/render.js
+++ b/src/coral/static/render.js
@@ -33,17 +33,16 @@ function formatStaleness(seconds) {
     return `${Math.floor(seconds / 3600)}h ago`;
 }
 
-function getStateLabel(waitingForInput, working, staleness, waitingReason) {
-    if (waitingForInput) {
-        return waitingReason === "stop" ? "Done" : "Needs input";
-    }
-    if (working) return "Working";
-    if (staleness !== null && staleness !== undefined && staleness < 60) return "Active";
+function getStateLabel(s) {
+    if (s.waiting_for_input) return "Needs input";
+    if (s.stuck) return "Stuck";
+    if (s.working) return "Working";
+    if (s.done) return "Done";
     return "Idle";
 }
 
 function buildSessionTooltip(s) {
-    const stateLabel = getStateLabel(s.waiting_for_input, s.working, s.staleness_seconds, s.waiting_reason);
+    const stateLabel = getStateLabel(s);
     const lastAction = formatStaleness(s.staleness_seconds);
     const goal = s.summary || "No goal set";
     const status = s.status || "No status";
@@ -66,11 +65,11 @@ function buildSessionTooltip(s) {
     return `<table class="session-tooltip-table">${rows.join("")}</table>`;
 }
 
-function getDotClass(staleness, waitingForInput, working, waitingReason) {
-    if (waitingForInput) return waitingReason === "stop" ? "done" : "waiting";
-    if (working) return "working";
-    if (staleness === null || staleness === undefined) return "stale";
-    if (staleness < 60) return "active";
+function getDotClass(s) {
+    if (s.waiting_for_input) return "waiting";
+    if (s.stuck) return "stuck";
+    if (s.working) return "working";
+    if (s.done) return "done";
     return "stale";
 }
 
@@ -312,15 +311,15 @@ export async function saveTeamFromSidebar(boardName) {
 let _draggedSid = null;
 
 function _renderSessionItem(s, groupName, isCompact, collapsed) {
-    const dotClass = getDotClass(s.staleness_seconds, s.waiting_for_input, s.working, s.waiting_reason);
+    const dotClass = getDotClass(s);
     const isActive = state.currentSession && state.currentSession.type === "live" && state.currentSession.session_id === s.session_id;
     const typeTag = s.agent_type && s.agent_type !== "claude" ? ` <span class="badge ${escapeHtml(s.agent_type)}">${escapeHtml(s.agent_type)}</span>` : "";
     // Branch is shown at folder level, not per agent
     const branchTag = "";
     const waitingBadge = s.waiting_for_input
-        ? (s.waiting_reason === "stop"
-            ? ' <span class="badge done-badge">Done</span>'
-            : ' <span class="badge waiting-badge">Needs input</span>')
+        ? ' <span class="badge waiting-badge">Needs input</span>'
+        : s.done
+        ? ' <span class="badge done-badge">Done</span>'
         : '';
     const isTerminal = s.agent_type === "terminal";
     const sid = s.session_id ? escapeHtml(s.session_id) : "";
@@ -702,20 +701,21 @@ export function updateSessionBranch(branch) {
     }
 }
 
-export function updateWaitingIndicator(waiting, working, waitingReason) {
+export function updateWaitingIndicator(s) {
     const dot = document.getElementById("session-status-dot");
     const banner = document.getElementById("waiting-banner");
-    const isDone = waiting && waitingReason === "stop";
     if (dot) {
-        dot.classList.toggle("waiting", !!waiting && !isDone);
-        dot.classList.toggle("done", isDone);
-        dot.classList.toggle("working", !!working);
+        dot.classList.toggle("waiting", !!s.waiting_for_input);
+        dot.classList.toggle("stuck", !!s.stuck);
+        dot.classList.toggle("working", !!s.working);
+        dot.classList.toggle("done", !!s.done);
     }
     if (banner) {
-        banner.style.display = waiting ? "" : "none";
-        if (waiting) {
-            banner.className = isDone ? "waiting-banner done-banner" : "waiting-banner";
-            banner.textContent = isDone ? "✅ Agent is done" : "⏳ Agent is waiting for input";
+        // Only show banner for needs-input state
+        banner.style.display = s.waiting_for_input ? "" : "none";
+        if (s.waiting_for_input) {
+            banner.className = "waiting-banner";
+            banner.textContent = "⏳ Agent is waiting for input";
         }
     }
 }

--- a/src/coral/static/sessions.js
+++ b/src/coral/static/sessions.js
@@ -78,7 +78,7 @@ export async function selectLiveSession(name, agentType, sessionId) {
     // Update branch and waiting indicator from live sessions data
     const agent = state.liveSessions.find(s => s.session_id === sessionId);
     updateSessionBranch(agent && agent.branch ? agent.branch : null);
-    updateWaitingIndicator(agent ? agent.waiting_for_input : false, agent ? agent.working : false, agent ? agent.waiting_reason : null);
+    updateWaitingIndicator(agent || {});
 
     // Set up quick action buttons
     state.currentCommands = (agent && agent.commands) || { compress: "/compact", clear: "/clear" };

--- a/src/coral/static/websocket.js
+++ b/src/coral/static/websocket.js
@@ -50,9 +50,7 @@ export function connectCoralWs() {
                 const id = s.session_id || s.name;
                 const wasWaiting = state.prevWaitingState[id];
                 const notifyEnabled = state.settings.notify_needs_input !== false;
-                // A "stop" event with "waiting for input" in the summary is a real input request
-                const isRealStop = s.waiting_reason === "stop" && !(s.waiting_summary || "").toLowerCase().includes("waiting for input");
-                if (notifyEnabled && s.waiting_for_input && !isRealStop && !wasWaiting) {
+                if (notifyEnabled && s.waiting_for_input && !wasWaiting) {
                     const label = escapeHtml(s.display_name || s.name);
                     const detail = s.waiting_summary ? escapeHtml(s.waiting_summary) : null;
                     const sessionName = s.name;
@@ -62,7 +60,7 @@ export function connectCoralWs() {
                         import('./sessions.js').then(m => m.selectLiveSession(sessionName, agentType, sessionId));
                     });
                 }
-                state.prevWaitingState[id] = s.waiting_for_input && !isRealStop;
+                state.prevWaitingState[id] = !!s.waiting_for_input;
             }
 
             state.liveSessions = data.sessions;
@@ -108,7 +106,7 @@ export function connectCoralWs() {
                     updateSessionStatus(s.status);
                     updateSessionSummary(s.summary);
                     updateSessionBranch(s.branch);
-                    updateWaitingIndicator(s.waiting_for_input, s.working, s.waiting_reason);
+                    updateWaitingIndicator(s);
                     updateChangedFileCount(s.changed_file_count || 0);
                 }
             }

--- a/tests/test_performance_paths.py
+++ b/tests/test_performance_paths.py
@@ -519,7 +519,7 @@ async def test_idle_detector_notifies_stale_waiting(tmp_path):
         {"id": 1, "agent_filter": None},
     ]
     mock_store.get_latest_event_types.return_value = {
-        "sess-1": ("stop", "Waiting for input"),
+        "sess-1": ("notification", "Permission prompt"),
     }
     mock_store.create_webhook_delivery = AsyncMock()
 
@@ -551,7 +551,7 @@ async def test_idle_detector_only_notifies_once(tmp_path):
         {"id": 1, "agent_filter": None},
     ]
     mock_store.get_latest_event_types.return_value = {
-        "sess-1": ("stop", "Waiting"),
+        "sess-1": ("notification", "Permission prompt"),
     }
     mock_store.create_webhook_delivery = AsyncMock()
 


### PR DESCRIPTION
Summary

  - Add pre-parse diagnostic logging to agentic_state hook so stdin read errors and JSON parse failures are always logged (previously exited silently)
  - Refine session state model: replace binary waiting_for_input/working with distinct working, done, stuck, and needs_input states
  - Update frontend dot rendering, animations, and CSS to reflect the new state model
  - Lower stuck detection threshold from 10 minutes to 7 minutes
  - Update tests to match new state field names

  Test plan

  - All 327 tests pass
  - Launch agent, submit a prompt — dot turns blue (working)
  - Agent completes task — dot turns green (done
  - Agent waiting for input — dot shows correct idle state
  - Check $TMPDIR/coral_task_cache/debug.log shows AGENTIC_STATE RAW(...) entries on every hook invocation
  
  https://www.loom.com/share/5119cad9e29e4f6e8cecc80c452aa8ec