### PR TITLE
feat: improve agent launch modal UI and sidebar group actions

### DIFF
--- a/src/coral/static/app.js
+++ b/src/coral/static/app.js
@@ -8,7 +8,7 @@ import { filterState, deserializeFromUrl, serializeToUrl,
 import { connectCoralWs } from './websocket.js';
 import { sendCommand, sendRawKeys, sendModeToggle, cycleModeToggle, sendQuickCommand, executeMacro, addMacro, deleteMacro, showMacroModal, hideMacroModal, attachTerminal, killSession, restartSession, hideRestartModal, confirmRestart, initImageDrop, removeAttachment, editGoal, refreshGoal, requestGoal } from './controls.js';
 import { selectLiveSession, selectHistorySession, editAndResubmit, renameAgent } from './sessions.js';
-import { toggleGroupCollapse, killGroup, shareAgentTeam, saveTeamFromSidebar, killSessionDirect, showInfoDirect, attachDirect, restartDirect, showConfirmModal, hideConfirmModal } from './render.js';
+import { toggleGroupCollapse, killGroup, killBoard, shareAgentTeam, saveTeamFromSidebar, killSessionDirect, showInfoDirect, attachDirect, restartDirect, showConfirmModal, hideConfirmModal, copyFolderPath } from './render.js';
 import { syncPaneWidth, refreshCapture } from './capture.js';
 import { showLaunchModal, hideLaunchModal, launchSession, showInfoModal, hideInfoModal, copyInfoCommand, showResumeModal, hideResumeModal, resumeIntoSession, showSettingsModal, hideSettingsModal, applySettings, loadSettings, toggleFlag, showAddAgentToBoard, hideAddAgentBoardModal, launchAgentToBoard, exportPersonas, importPersonas, exportTeamTemplates, importTeamTemplates } from './modals.js';
 import { toggleBrowser, browserNavigateTo, browserNavigateUp } from './browser.js';
@@ -169,6 +169,8 @@ window.toggleSidebarKebab = toggleSidebarKebab;
 window.closeSidebarKebabs = closeSidebarKebabs;
 window.toggleGroupCollapse = toggleGroupCollapse;
 window.killGroup = killGroup;
+window.copyFolderPath = copyFolderPath;
+window.killBoard = killBoard;
 window.shareAgentTeam = shareAgentTeam;
 window.saveTeamFromSidebar = saveTeamFromSidebar;
 window.showConfirmModal = showConfirmModal;

--- a/src/coral/static/css/components.css
+++ b/src/coral/static/css/components.css
@@ -1127,6 +1127,60 @@
     line-height: 1.4;
 }
 
+.agent-three-columns {
+    display: grid;
+    grid-template-columns: 1fr 180px 1fr;
+    gap: 20px;
+    margin-bottom: 12px;
+}
+
+.agent-col-presets {
+    min-width: 0;
+}
+
+.agent-col-config,
+.agent-col-fields {
+    min-width: 0;
+}
+
+.agent-col-fields {
+    display: flex;
+    flex-direction: column;
+}
+
+.agent-prompt-label {
+    margin-bottom: 4px !important;
+}
+
+.agent-col-fields textarea {
+    flex: 1;
+    min-height: 120px;
+    resize: vertical;
+}
+
+.agent-preset-vertical {
+    flex-direction: column;
+    align-items: stretch;
+    border-bottom: none;
+    padding-bottom: 8px;
+    margin-bottom: 8px;
+}
+
+.agent-preset-vertical .agent-preset-btn {
+    text-align: left;
+}
+
+.modal-content-agent-wide {
+    width: 1050px;
+}
+
+/* Locked preset fields */
+.preset-locked {
+    opacity: 0.6;
+    background: var(--bg-primary) !important;
+    cursor: default;
+}
+
 .team-columns {
     display: grid;
     grid-template-columns: 1fr 1fr;
@@ -1384,6 +1438,9 @@
 .agent-preset-saved {
     background: transparent;
     border-style: dashed;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
 }
 
 .agent-preset-saved.active {
@@ -1392,7 +1449,8 @@
 }
 
 .agent-preset-delete {
-    margin-left: 4px;
+    margin-left: auto;
+    padding-left: 8px;
     font-size: 14px;
     opacity: 0;
     transition: opacity 0.15s;

--- a/src/coral/static/css/session.css
+++ b/src/coral/static/css/session.css
@@ -320,7 +320,7 @@
     font-size: 9px;
     font-weight: 500;
     color: var(--text-muted);
-    padding: 6px 16px 2px !important;
+    padding: 4px 16px !important;
     text-transform: uppercase;
     letter-spacing: 0.05em;
     cursor: pointer;
@@ -370,6 +370,11 @@
     font-size: 13px;
     padding: 1px 3px;
     opacity: 0;
+    align-self: center;
+}
+
+.group-kebab {
+    align-self: center;
 }
 
 .session-group-header:hover .group-kebab .sidebar-kebab-btn {
@@ -420,25 +425,27 @@
     flex: 1;
 }
 
-.folder-tag-btn {
+.folder-copy-btn {
     display: none;
-    font-size: 11px;
     cursor: pointer;
     color: var(--text-muted);
-    padding: 0 4px;
+    padding: 2px 4px;
     border-radius: 3px;
     background: none;
     border: none;
     line-height: 1;
+    flex-shrink: 0;
+    align-self: center;
 }
 
-.folder-tag-btn:hover {
+.folder-copy-btn:hover {
     color: var(--text-primary);
     background: var(--bg-hover);
 }
 
-.session-group-header:hover .folder-tag-btn {
-    display: inline-block;
+.session-group-header:hover .folder-copy-btn {
+    display: inline-flex;
+    align-items: center;
 }
 
 .session-group-item {

--- a/src/coral/static/modals.js
+++ b/src/coral/static/modals.js
@@ -3,6 +3,7 @@
 import { state } from './state.js';
 import { showToast, escapeHtml, escapeAttr } from './utils.js';
 import { loadLiveSessions } from './api.js';
+import { loadBoardProjects } from './message_board.js';
 import { getEngineNames, getEngineName, setRendererOverride } from './renderers.js';
 import { renderCaptureText, syncPaneWidth } from './capture.js';
 import { hideRestartModal } from './controls.js';
@@ -31,12 +32,12 @@ function _showLaunchStep(step) {
     document.getElementById("launch-step-agent").style.display = step === "agent" ? "" : "none";
     document.getElementById("launch-step-terminal").style.display = step === "terminal" ? "" : "none";
     document.getElementById("launch-step-team").style.display = step === "team" ? "" : "none";
-    // Widen the modal for two-column layouts (agent and team forms)
+    // Widen the modal for multi-column layouts
     const content = document.querySelector("#launch-modal .modal-content");
     if (content) {
-        const wide = step === "team" || step === "agent";
-        content.classList.toggle("modal-content-extra-wide", wide);
-        content.classList.toggle("modal-content-wide", !wide);
+        content.classList.toggle("modal-content-agent-wide", step === "agent");
+        content.classList.toggle("modal-content-extra-wide", step === "team");
+        content.classList.toggle("modal-content-wide", step !== "team" && step !== "agent");
     }
 }
 
@@ -75,8 +76,16 @@ export function showLaunchModal() {
     document.getElementById("launch-new-board-row").style.display = "none";
     document.getElementById("launch-board-server-row").style.display = "none";
     _syncFlagButtons("launch-flags");
-    // Clear preset selection
+    // Clear preset selection and unlock fields
     document.querySelectorAll("#agent-preset-selector .agent-preset-btn").forEach(btn => btn.classList.remove("active"));
+    const agentNameInput = document.getElementById("launch-agent-name");
+    const agentPromptInput = document.getElementById("launch-agent-prompt");
+    agentNameInput.readOnly = false;
+    agentPromptInput.readOnly = false;
+    agentNameInput.classList.remove("preset-locked");
+    agentPromptInput.classList.remove("preset-locked");
+    const savePersonaBtn = document.getElementById("agent-save-persona-btn");
+    if (savePersonaBtn) savePersonaBtn.style.display = "";
 
     // Reset terminal form
     document.getElementById("launch-terminal-name").value = "";
@@ -385,6 +394,7 @@ function _initAgentPresets() {
 function _selectAgentPreset(name) {
     const nameInput = document.getElementById("launch-agent-name");
     const promptInput = document.getElementById("launch-agent-prompt");
+    const saveBtn = document.getElementById("agent-save-persona-btn");
 
     if (name) {
         const persona = _findPersona(name);
@@ -397,11 +407,19 @@ function _selectAgentPreset(name) {
         promptInput.value = "";
     }
 
+    // Lock fields for built-in presets (they can't be saved/overwritten)
+    const isBuiltIn = !!AGENT_PRESETS.find(p => p.name === name);
+    nameInput.readOnly = isBuiltIn;
+    promptInput.readOnly = isBuiltIn;
+    nameInput.classList.toggle("preset-locked", isBuiltIn);
+    promptInput.classList.toggle("preset-locked", isBuiltIn);
+    if (saveBtn) saveBtn.style.display = isBuiltIn ? "none" : "";
+
     document.querySelectorAll("#agent-preset-selector .agent-preset-btn").forEach(btn => {
         btn.classList.toggle("active", btn.dataset.preset === name);
     });
 
-    nameInput.focus();
+    if (!isBuiltIn) nameInput.focus();
 }
 window._selectAgentPreset = _selectAgentPreset;
 
@@ -712,12 +730,19 @@ function _showAddAgentPicker() {
 
     // Build picker items: presets not already in the list
     const available = AGENT_PRESETS.filter(p => !existingNames.has(p.name.toLowerCase()));
+    const savedAvailable = _getSavedPersonas().filter(p => !existingNames.has(p.name.toLowerCase()));
 
     let html = '';
     for (const preset of available) {
         html += `<button class="agent-picker-item" onclick="window._addPresetAgent('${escapeAttr(preset.name)}')">${escapeHtml(preset.name)}</button>`;
     }
-    if (available.length > 0) {
+    if (savedAvailable.length > 0) {
+        if (available.length > 0) html += '<div class="agent-picker-divider"></div>';
+        for (const persona of savedAvailable) {
+            html += `<button class="agent-picker-item agent-preset-saved" onclick="window._addPresetAgent('${escapeAttr(persona.name)}')">${escapeHtml(persona.name)}</button>`;
+        }
+    }
+    if (available.length > 0 || savedAvailable.length > 0) {
         html += '<div class="agent-picker-divider"></div>';
     }
     html += `<button class="agent-picker-item agent-picker-custom" onclick="window._addTeamAgent()">+ Create Custom</button>`;
@@ -737,9 +762,9 @@ function _showAddAgentPicker() {
 window._showAddAgentPicker = _showAddAgentPicker;
 
 function _addPresetAgent(name) {
-    const preset = AGENT_PRESETS.find(p => p.name === name);
-    if (preset) {
-        _addTeamAgent(preset.name, preset.prompt);
+    const persona = _findPersona(name);
+    if (persona) {
+        _addTeamAgent(persona.name, persona.prompt);
     }
     const picker = document.getElementById("team-agent-picker");
     if (picker) picker.style.display = "none";
@@ -823,6 +848,7 @@ async function launchTeam() {
             showToast(`Launched team: ${agents.length} agents on "${boardName}"`);
             hideLaunchModal();
             setTimeout(loadLiveSessions, 2000);
+            setTimeout(loadBoardProjects, 4000);
         }
     } catch (e) {
         showToast("Failed to launch team", true);

--- a/src/coral/static/render.js
+++ b/src/coral/static/render.js
@@ -196,6 +196,13 @@ export function hideConfirmModal() {
     document.getElementById("confirm-modal").style.display = "none";
 }
 
+export function copyFolderPath(path) {
+    if (!path) return;
+    navigator.clipboard.writeText(path).then(() => {
+        showToast("Copied path to clipboard");
+    });
+}
+
 export async function killGroup(groupName) {
     const groupSessions = state.liveSessions.filter(s => (s.name || 'unknown') === groupName);
     if (!groupSessions.length) return;
@@ -216,6 +223,32 @@ export async function killGroup(groupName) {
                 }
             }
             const killedIds = new Set(groupSessions.map(s => s.session_id));
+            state.liveSessions = state.liveSessions.filter(s => !killedIds.has(s.session_id));
+            renderLiveSessions(state.liveSessions);
+        }
+    );
+}
+
+export async function killBoard(boardName) {
+    const boardSessions = state.liveSessions.filter(s => s.board_project === boardName);
+    if (!boardSessions.length) return;
+
+    showConfirmModal(
+        "Kill Team",
+        `Kill all ${boardSessions.length} agent(s) on board "${boardName}"? This will terminate them.`,
+        async () => {
+            for (const s of boardSessions) {
+                try {
+                    await fetch(`/api/sessions/live/${encodeURIComponent(s.name)}/kill`, {
+                        method: "POST",
+                        headers: { "Content-Type": "application/json" },
+                        body: JSON.stringify({ agent_type: s.agent_type, session_id: s.session_id }),
+                    });
+                } catch (e) {
+                    console.error(`Failed to kill ${s.name}:`, e);
+                }
+            }
+            const killedIds = new Set(boardSessions.map(s => s.session_id));
             state.liveSessions = state.liveSessions.filter(s => !killedIds.has(s.session_id));
             renderLiveSessions(state.liveSessions);
         }
@@ -411,6 +444,10 @@ export function renderLiveSessions(sessions) {
         const groupKebab = `<div class="sidebar-kebab-wrapper group-kebab">
             <button class="sidebar-kebab-btn group-kebab-btn" onclick="event.stopPropagation(); toggleSidebarKebab(this)" title="Group actions">&#x22EE;</button>
             <div class="sidebar-kebab-menu" style="display:none">
+                <button class="overflow-menu-item" onclick="event.stopPropagation(); closeSidebarKebabs(); showFolderTagDropdown('${escapeAttr(groupName)}', this.closest('.session-group-header'))">
+                    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 8.5V3a1 1 0 0 1 1-1h5.5l5.5 5.5-5.5 5.5L2 8.5z"/><circle cx="5.5" cy="5.5" r="1" fill="currentColor" stroke="none"/></svg>
+                    Manage Tags
+                </button>
                 <button class="overflow-menu-item overflow-menu-danger" onclick="event.stopPropagation(); closeSidebarKebabs(); killGroup('${escapeHtml(groupName)}')">
                     <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><line x1="4" y1="4" x2="12" y2="12"/><line x1="12" y1="4" x2="4" y2="12"/></svg>
                     Kill All
@@ -421,9 +458,10 @@ export function renderLiveSessions(sessions) {
         const groupBranchLine = groupBranch ? `<div class="group-branch-line"><svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 3v5a3 3 0 0 0 3 3h1"/><circle cx="6" cy="3" r="1.5"/><circle cx="11" cy="11" r="1.5"/></svg> ${escapeHtml(groupBranch)}</div>` : "";
         const fTags = getFolderTags(groupName);
         const tagDots = renderFolderTagPills(fTags);
-        const tagBtn = `<button class="folder-tag-btn" onclick="event.stopPropagation(); showFolderTagDropdown('${escapeAttr(groupName)}', this.closest('.session-group-header'))" title="Manage tags">+</button>`;
+        const groupWorkDir = sorted[0]?.working_directory || '';
+        const copyBtn = `<button class="folder-copy-btn" onclick="event.stopPropagation(); copyFolderPath('${escapeAttr(groupWorkDir)}')" title="Copy path"><svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="5.5" y="5.5" width="8" height="8" rx="1.5"/><path d="M5.5 10.5h-1a1.5 1.5 0 0 1-1.5-1.5v-5a1.5 1.5 0 0 1 1.5-1.5h5a1.5 1.5 0 0 1 1.5 1.5v1"/></svg></button>`;
         html += `<li class="session-group-header" data-group-name="${escapeHtml(groupName)}" onclick="toggleGroupCollapse('${escapeHtml(groupName)}')">
-            <span class="group-chevron">${chevron}</span><div class="group-header-text"><div class="group-name-line">${escapeHtml(groupName)}${countBadge}</div>${groupBranchLine}</div>${tagDots}<span class="session-name-spacer"></span>${tagBtn}${groupKebab}</li>`;
+            <span class="group-chevron">${chevron}</span><div class="group-header-text"><div class="group-name-line">${escapeHtml(groupName)}${countBadge}</div>${groupBranchLine}</div>${tagDots}<span class="session-name-spacer"></span>${copyBtn}${groupKebab}</li>`;
 
         if (collapsed) {
             // Skip rendering items when collapsed
@@ -463,7 +501,7 @@ export function renderLiveSessions(sessions) {
                             Share Team
                         </button>
                         <hr class="overflow-menu-divider">
-                        <button class="overflow-menu-item overflow-menu-danger" onclick="event.stopPropagation(); closeSidebarKebabs(); killGroup('${escapeHtml(groupName)}')">
+                        <button class="overflow-menu-item overflow-menu-danger" onclick="event.stopPropagation(); closeSidebarKebabs(); killBoard('${escapeAttr(boardName)}')">
                             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><line x1="4" y1="4" x2="12" y2="12"/><line x1="12" y1="4" x2="4" y2="12"/></svg>
                             Kill All
                         </button>

--- a/src/coral/templates/includes/modals.html
+++ b/src/coral/templates/includes/modals.html
@@ -46,14 +46,14 @@
                 </div>
             </div>
 
-            <!-- Step 2a: Agent form (two-column layout matching team form) -->
+            <!-- Step 2a: Agent form (three-column layout) -->
             <div id="launch-step-agent" style="display:none">
                 <h3>
                     <button class="launch-back-btn" onclick="window._selectLaunchType('back')" title="Back">&larr;</button>
                     Launch AI Agent
                 </h3>
-                <div class="team-columns">
-                    <div class="team-col-left">
+                <div class="agent-three-columns">
+                    <div class="agent-col-config">
                         <label>Message Board <span style="color:var(--text-muted);font-weight:normal">(optional)</span>:
                             <select id="launch-board-select" onchange="window._onAgentBoardChange()">
                                 <option value="">None</option>
@@ -99,37 +99,26 @@
                             <button class="btn btn-small flag-shortcut-btn" onclick="toggleFlag('launch-flags','--dangerously-skip-permissions')">--dangerously-skip-permissions</button>
                         </div>
                     </div>
-                    <div class="team-col-right">
-                        <div class="team-agents-container">
-                            <div class="team-agents-header">
-                                <strong style="font-size:14px">Agent</strong>
-                                <p class="team-agents-desc">Choose a preset role or configure a custom agent.</p>
-                            </div>
-                            <div id="agent-preset-selector" class="agent-preset-selector"></div>
-                            <div class="import-export-row">
-                                <button class="btn btn-small btn-subtle" onclick="exportPersonas()" title="Export saved personas">Export</button>
-                                <button class="btn btn-small btn-subtle" onclick="importPersonas()" title="Import personas from file">Import</button>
-                            </div>
-                            <div class="team-agents-scroll">
-                                <div class="team-agent-row">
-                                    <div class="team-agent-card editing">
-                                        <div class="team-agent-form">
-                                            <label>Name / Role <span style="color:var(--text-muted);font-weight:normal">(optional)</span>:
-                                                <input type="text" id="launch-agent-name" class="team-agent-name" placeholder="e.g. Auth Feature, Bug Fix #123">
-                                            </label>
-                                            <label>Behavior Prompt <span style="color:var(--text-muted);font-weight:normal">(optional)</span>:
-                                                <textarea id="launch-agent-prompt" class="team-agent-prompt" rows="5" placeholder="e.g. You are a QA engineer. Review the codebase and create a test plan..."></textarea>
-                                            </label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
+                    <div class="agent-col-presets">
+                        <strong style="font-size:13px">Persona</strong>
+                        <p class="team-agents-desc">Choose a preset or custom.</p>
+                        <div id="agent-preset-selector" class="agent-preset-selector agent-preset-vertical"></div>
+                        <div class="import-export-row">
+                            <button class="btn btn-small btn-subtle" onclick="exportPersonas()" title="Export saved personas">Export</button>
+                            <button class="btn btn-small btn-subtle" onclick="importPersonas()" title="Import personas from file">Import</button>
                         </div>
+                    </div>
+                    <div class="agent-col-fields">
+                        <label>Name / Role <span style="color:var(--text-muted);font-weight:normal">(optional)</span>:
+                            <input type="text" id="launch-agent-name" class="team-agent-name" placeholder="e.g. Auth Feature, Bug Fix #123">
+                        </label>
+                        <label class="agent-prompt-label" for="launch-agent-prompt">Behavior Prompt <span style="color:var(--text-muted);font-weight:normal">(optional)</span>:</label>
+                        <textarea id="launch-agent-prompt" class="team-agent-prompt" rows="5" placeholder="e.g. You are a QA engineer. Review the codebase and create a test plan..."></textarea>
                     </div>
                 </div>
                 <div class="modal-actions">
                     <button class="btn" onclick="hideLaunchModal()">Cancel</button>
-                    <button class="btn btn-save-persona" onclick="window._saveCurrentPersona('launch-agent-name','launch-agent-prompt','launch-flags')" title="Save as reusable persona">Save Persona</button>
+                    <button class="btn btn-save-persona" id="agent-save-persona-btn" onclick="window._saveCurrentPersona('launch-agent-name','launch-agent-prompt','launch-flags')" title="Save as reusable persona">Save Persona</button>
                     <button class="btn btn-primary" onclick="launchSession()">Launch</button>
                 </div>
             </div>


### PR DESCRIPTION
Summary

  - Redesign agent launch modal from two-column to three-column layout (config, persona presets, name/prompt fields)
  - Lock name and prompt fields when a built-in preset is selected (prevent accidental edits)
  - Add killBoard action to kill all agents on a message board team (distinct from killGroup which kills by folder)
  - Replace folder tag + button with a copy-path button in sidebar group headers
  - Move "Manage Tags" into the group kebab menu
  - Include saved personas in the team agent picker alongside built-in presets
  - Auto-refresh board projects list after launching a team

  Test plan

  - Open the +New modal and select "AI Agent" — verify three-column layout renders correctly
  - Select a built-in preset — verify name and prompt fields become read-only and "Save Persona" button hides
  - Select a saved persona or clear selection — verify fields are editable again
  - Launch a team, confirm the board list refreshes after a few seconds
  - In the sidebar, hover a group header — verify copy button appears and copies the working directory path
  - Open the group kebab menu — verify "Manage Tags" option is present
  - For a board group, use the kebab "Kill All" — verify it kills by board membership (not folder name)
  - Open the team agent picker (+ in team form) — verify saved personas appear below built-in presets
  
  
  https://www.loom.com/share/80dbf79aae044af7bc1a53ecfcd009f4